### PR TITLE
Add support for a row-oriented API

### DIFF
--- a/parquet-column/src/main/java/parquet/column/impl/ColumnReadStoreImpl.java
+++ b/parquet-column/src/main/java/parquet/column/impl/ColumnReadStoreImpl.java
@@ -60,6 +60,7 @@ public class ColumnReadStoreImpl implements ColumnReadStore {
   }
 
   //FIXME plug in the new vector reader for testing
+  // similar to hive, vectorized reads should be enabled through configuration (false by default)
   public static boolean VECTORIZATION_ENABLED = true;
   private ColumnReader newMemColumnReader(ColumnDescriptor path, PageReader pageReader) {
     PrimitiveConverter converter = getPrimitiveConverter(path);

--- a/parquet-column/src/main/java/parquet/vector/DoubleColumnVector.java
+++ b/parquet-column/src/main/java/parquet/vector/DoubleColumnVector.java
@@ -16,7 +16,7 @@ public class DoubleColumnVector extends ColumnVector
 
   public DoubleColumnVector(boolean isLazy) {
     super(double.class, isLazy);
-    values = new double[MAX_VECTOR_LENGTH];
+    values = new double[DEFAULT_VECTOR_LENGTH];
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/vector/FloatColumnVector.java
+++ b/parquet-column/src/main/java/parquet/vector/FloatColumnVector.java
@@ -16,7 +16,7 @@ public class FloatColumnVector extends ColumnVector
 
   public FloatColumnVector(boolean isLazy) {
     super(double.class, isLazy);
-    values = new float[MAX_VECTOR_LENGTH];
+    values = new float[DEFAULT_VECTOR_LENGTH];
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/vector/IntColumnVector.java
+++ b/parquet-column/src/main/java/parquet/vector/IntColumnVector.java
@@ -16,7 +16,7 @@ public class IntColumnVector extends ColumnVector
 
   public IntColumnVector(boolean isLazy) {
     super(int.class, isLazy);
-    values = new int[MAX_VECTOR_LENGTH];
+    values = new int[DEFAULT_VECTOR_LENGTH];
   }
 
   public ByteBuffer decode() {

--- a/parquet-column/src/main/java/parquet/vector/LongColumnVector.java
+++ b/parquet-column/src/main/java/parquet/vector/LongColumnVector.java
@@ -16,7 +16,7 @@ public class LongColumnVector extends ColumnVector
 
   public LongColumnVector(boolean isLazy) {
     super(int.class, isLazy);
-    values = new long[MAX_VECTOR_LENGTH];
+    values = new long[DEFAULT_VECTOR_LENGTH];
   }
 
   public ByteBuffer decode() {

--- a/parquet-column/src/main/java/parquet/vector/RowBatch.java
+++ b/parquet-column/src/main/java/parquet/vector/RowBatch.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.vector;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import static parquet.Preconditions.checkNotNull;
+
+public class RowBatch {
+
+  private int size;
+  private ColumnVector[] columns;
+
+  public int size() {
+    //TODO: see the FIXME in setColumns()
+    throw new NotImplementedException();
+//    return size;
+  }
+
+  public ColumnVector[] getColumns() {
+    return columns;
+  }
+
+  public void setColumns(ColumnVector[] columns) {
+    checkNotNull(columns, "columns");
+    this.columns = columns;
+
+    //FIXME given column vectors had different sizes in my tests, may be a bug somewhere
+//    size = -1;
+//    for(ColumnVector cv: columns) {
+//      if (size == -1) {
+//        size = cv.size();
+//      } else {
+//        if (size != cv.size()) {
+//          throw new RuntimeException("columns have different sizes");
+//        }
+//      }
+//    }
+  }
+}

--- a/parquet-hadoop/src/main/java/parquet/hadoop/InternalParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/InternalParquetRecordReader.java
@@ -248,7 +248,7 @@ class InternalParquetRecordReader<T> {
         total = 0;
     }
 
-    if (column != lastColumn) {
+    if (!column.equals(lastColumn)) {
         initializeVector(column);
         lastColumn = column;
     }


### PR DESCRIPTION
Added a `RowBatch` class. The client can now use the `public RowBatch nextBatch(RowBatch previous)` method of the `ParquetReader` class, see the unit test.
